### PR TITLE
ENH: add score hessian (numdiff), unit test add noise

### DIFF
--- a/statsmodels/regression/mixed_glm.py
+++ b/statsmodels/regression/mixed_glm.py
@@ -1029,6 +1029,23 @@ class MixedGLM(base.LikelihoodModel):
 
         return result.fun, mp
 
+    def score(self, params):
+        '''
+        Gradient of log-likelihood evaluated at params
+        '''
+        kwds = {}
+        kwds.setdefault('centered', True)
+        return approx_fprime(params, self.loglike, **kwds).ravel()
+
+
+    def hessian(self, params):
+        '''
+        Hessian of log-likelihood evaluated at params
+        '''
+        from statsmodels.tools.numdiff import approx_hess
+        # need options for hess (epsilon)
+        return approx_hess(params, self.loglike, centered=True)
+
     
     def fit(self, start_params=None, niter_sa=0,
             do_cg=True, fe_pen=None, cov_pen=None, free=None,

--- a/statsmodels/regression/tests/test_mixed_glm.py
+++ b/statsmodels/regression/tests/test_mixed_glm.py
@@ -15,7 +15,7 @@ def endog_gen(family,lin_pred, n_group, gsize):
         mn = np.exp(lin_pred)
         endog = np.random.gamma(shape=1,scale=mn)
     elif family == "Gaussian":
-        endog = .5 * lin_pred.sum()
+        endog = .5 * lin_pred + np.random.randn(len(lin_pred)) #.sum()
     else:
         1/0
 


### PR DESCRIPTION
trying out:

unit test had wrong shape of endog and no noise

add score and hessian as methods using plain numdiff 
In example hessian diagonal of last param is negative
